### PR TITLE
correct from-font, docs for fontConvertSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ knayi([String]).fontConvert([to], function(edited_content, old_content){
 Sync version
 ```js
 var knayi = require("knayi-myscript");
-var edited = knayi([String]).fonConvertSync([to]);
+var edited = knayi([String]).fontConvertSync([to]);
 ```
 
 FontType

--- a/npm/index.js
+++ b/npm/index.js
@@ -362,7 +362,7 @@ knayi.fn = knayi.prototype = {
 	 */
 	fontConvertSync: function(to){
 		var to = to || "unicode5";
-		return ( this.edited = fontConvert(this.content, to) );
+		return ( this.edited = fontConvert(this.content, to, this.knyData.fontType) );
 	},
 
 	syllableSync: function(lang){


### PR DESCRIPTION
I can't convert Unicode -> Zawgyi unless the from-font is specified

also fixes a small spelling mistake in the docs